### PR TITLE
update puma to 6.4 and fix string nil bug

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -8,7 +8,7 @@ end
 
 gem 'rails'
 gem 'pg'
-gem 'puma', '~> 3.0'
+gem 'puma', '~> 6.4'
 gem 'sass-rails'
 gem 'uglifier', '>= 1.3.0'
 gem 'jquery-rails'

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -232,7 +232,8 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (5.0.1)
-    puma (3.12.6)
+    puma (6.4.0)
+      nio4r (~> 2.0)
     pundit (2.3.0)
       activesupport (>= 3.0.0)
     racc (1.7.1)
@@ -387,7 +388,7 @@ DEPENDENCIES
   pg_search
   pry-byebug
   pry-rails
-  puma (~> 3.0)
+  puma (~> 6.4)
   pundit
   rack-cors
   rails

--- a/rails/app/models/development.rb
+++ b/rails/app/models/development.rb
@@ -131,9 +131,9 @@ class Development < ApplicationRecord
       logger.debug "entering geocoding"
       logger.debug properties['address']['city']
       self.update_columns(
-        municipal: (properties['address']['city'] || self.municipal),
-        address: ((properties['address']['house_number'] || '')+' '+ properties['address']['road'] || self.address),
-        zip_code: (properties['address']['postcode'] || self.zip_code)
+        municipal: (properties['address']['city'].to_s || self.municipal),
+        address: ((properties['address']['house_number'].to_s || '')+' '+ properties['address']['road'].to_s || self.address),
+        zip_code: (properties['address']['postcode'].to_s || self.zip_code)
         )
     end
     


### PR DESCRIPTION
Resolves #103 .

# Why is this change necessary?
Take advantage of most updated puma and fix nil string returned by osm geocoding services
# How does it address the issue?

# What side effects does it have?
Seems none