### PR TITLE
#132 associate users with agency in signup

### DIFF
--- a/ember/app/components/signup-subpanel.js
+++ b/ember/app/components/signup-subpanel.js
@@ -20,11 +20,13 @@ export default class extends Component {
     this.username = '';
     this.password = '';
     this.municipality = null;
+    this.agency=null;
     this.confirmPassword = '';
 
     this.errorMessage = null;
 
     this.munis = [];
+    this.rpas=["AMBAG","SLOCOG","SRTA"];
     this.isFetching = false;
     this.muniFailure = false;
     this.requesting = null;
@@ -40,6 +42,12 @@ export default class extends Component {
   @action
   updateMunicipality(muni) {
     this.set('municipality', muni);
+  }
+
+ 
+  @action
+  updateAgency(agency) {
+    this.set('agency', agency);
   }
 
 
@@ -71,7 +79,13 @@ export default class extends Component {
     const municipality = requesting == 'municipal'
         ? this.get('municipality')
         : (requesting == 'state' ? 'STATE' : null);
-    const agency = email.endsWith('ambag.org')? 'AMBAG' : 'SLOCOG';
+    const agency = requesting=='state'
+        ? this.get('agency') 
+        : (email.endsWith('srta.org')
+          ? 'SRTA' 
+          : (email.endsWith('slocog.org') 
+            ? 'SLOCOG' 
+            : 'AMBAG'));
     const requestVerifiedStatus = !!requesting;
 
 
@@ -115,7 +129,7 @@ export default class extends Component {
      */
 
     if (noErrors) {
-      const userSchema = { firstName, lastName, email, password, municipality,agency, requestVerifiedStatus };
+      const userSchema = { firstName, lastName, email, password, municipality, agency, requestVerifiedStatus };
 
       this.set('loadingText', 'Signing Up');
       this.set('isCreating', true);

--- a/ember/app/controllers/map/users/index.js
+++ b/ember/app/controllers/map/users/index.js
@@ -3,6 +3,7 @@ import Controller from '@ember/controller';
 import { action, computed } from '@ember-decorators/object';
 import munis from '../../../utils/municipalities';
 
+
 export default class extends Controller {
 
   constructor() {
@@ -27,7 +28,7 @@ export default class extends Controller {
     const roleFilter = this.get('roleFilter');
     const searchQuery = this.get('searchQuery').toLowerCase();
 
-    const searchable = ['lastName', 'firstName', 'email', 'fullName', 'municipality'];
+    const searchable = ['lastName', 'firstName', 'email', 'fullName', 'municipality', 'agency'];
     let filteredUsers = copy(sortedUsers);
 
     if (roleFilter !== 'all') {
@@ -73,3 +74,4 @@ export default class extends Controller {
     user.save();
   }
 }
+

--- a/ember/app/templates/components/signup-subpanel.hbs
+++ b/ember/app/templates/components/signup-subpanel.hbs
@@ -73,6 +73,21 @@
           {{/loading-spinner}}
         </div>
       {{/if}}
+
+      {{#if (eq requesting 'state')}}
+        <div class="input-wrapper labeled">
+          <label>Choose the agency you are associated with</label>
+
+          {{#loading-spinner message="Loading RPAS" isLoading=isFetching}}
+            <select onchange={{action updateAgency value="target.value"}}>
+              <option disabled selected>Select RPA Agency</option>
+              {{#each rpas as |rpa|}}
+                 <option value={{rpa}}>{{rpa}}</option>
+              {{/each}}
+            </select>
+          {{/loading-spinner}}
+        </div>
+      {{/if}}
     {{/unless}}
 
     {{#if errorMessage}}

--- a/ember/app/templates/map/users/index.hbs
+++ b/ember/app/templates/map/users/index.hbs
@@ -24,7 +24,7 @@
     </div>
   </div>
 
-  {{input value=searchQuery placeholder='Search by First/Last Name or Email'}}
+  {{input value=searchQuery placeholder='Search by First/Last Name, Email, Municipality or Agency'}}
 
   <div class="table-wrapper">
     {{#if filteredUsers}}
@@ -33,6 +33,7 @@
           <td>Name</td>
           <td>Email</td>
           <td>Municipality</td>
+          <td>Agency</td>
           <td>Date Joined</td>
           <td>Role</td>
         </tr>
@@ -59,6 +60,7 @@
                 -
               {{/if}}
             </td>
+            <td>{{user.agency}}</td>
             <td>
               {{user.createdAt}}
             </td>

--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -78,7 +78,7 @@ class UsersController < ApplicationController
   # Only allow a trusted parameter "white list" through.
   def user_params
     respond_to do |format|
-      format.jsonapi { ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:email, :password, :role, :first_name, :last_name, :municipality, :request_verified_status]) }
+      format.jsonapi { ActiveModelSerializers::Deserialization.jsonapi_parse(params, only: [:email, :password, :role, :first_name, :last_name, :municipality, :agency, :request_verified_status]) }
     end
   end
 end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   has_many :flags
   after_initialize :set_default_role, if: :new_record?
   after_create :new_user_email
+  after_save :update_agency
 
   private
   def ensure_authentication_token
@@ -31,6 +32,19 @@ class User < ApplicationRecord
 
   def set_default_role
     self.role ||= :user
+  end
+
+  def update_agency
+    return if municipality.nil? || municipality=='STATE'
+    logger.debug municipality
+    rpa_query = <<~SQL
+      SELECT upper(acronym) as agency FROM ca_place p JOIN rpa_poly r 
+      ON st_contains(r.shape, st_centroid(p.geom)) 
+      WHERE position('#{self.municipality}' in upper(namelsad))>0;      
+    SQL
+    sql_result = ActiveRecord::Base.connection.exec_query(rpa_query).to_a[0]
+    return if sql_result.blank?
+    self.update_columns(agency: sql_result['agency'])
   end
 
   


### PR DESCRIPTION
Resolves # .

# Why is this change necessary?
Associate users with agency in signup
# How does it address the issue?
Query rpa acronym based on municipal centroid or use agency selected by users or based on user email
# What side effects does it have?
None